### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,9 @@ for t in range(500):
   print(t, loss.data[0])
   
   # Manually zero the gradients before running the backward pass
-  w1.grad.data.zero_()
-  w2.grad.data.zero_()
+  if t:
+    w1.grad.data.zero_()
+    w2.grad.data.zero_()
 
   # Use autograd to compute the backward pass. This call will compute the
   # gradient of loss with respect to all Variables with requires_grad=True.


### PR DESCRIPTION
In the latest pytorch, grad data is not created until loss.backward() is called once. So, it throws an error without the condition.