### PR TITLE
Fix incorrect comments saying "gradient of x wrt to loss".

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ for t in range(500):
   loss = np.square(y_pred - y).sum()
   print(t, loss)
   
-  # Backprop to compute gradients of w1 and w2 with respect to loss
+  # Backprop to compute gradients of loss with respect to w1 and w2
   grad_y_pred = 2.0 * (y_pred - y)
   grad_w2 = h_relu.T.dot(grad_y_pred)
   grad_h_relu = grad_y_pred.dot(w2.T)
@@ -125,7 +125,7 @@ for t in range(500):
   loss = (y_pred - y).pow(2).sum()
   print(t, loss)
 
-  # Backprop to compute gradients of w1 and w2 with respect to loss
+  # Backprop to compute gradients of loss with respect to w1 and w2
   grad_y_pred = 2.0 * (y_pred - y)
   grad_w2 = h_relu.t().mm(grad_y_pred)
   grad_h_relu = grad_y_pred.mm(w2.t())
@@ -157,8 +157,8 @@ this graph then allows you to easily compute gradients.
 This sounds complicated, it's pretty simple to use in practice. We wrap our
 PyTorch Tensors in **Variable** objects; a Variable represents a node in a
 computational graph. If `x` is a Variable then `x.data` is a Tensor, and
-`x.grad` is another Variable holding the gradient of `x` with respect to some
-scalar value.
+`x.grad` is another Variable holding the gradient of some scalar value with
+respect to `x`.
 
 PyTorch Variables have the same API as PyTorch Tensors: (almost) any operation
 that you can perform on a Tensor also works on Variables; the difference is that

--- a/README_raw.md
+++ b/README_raw.md
@@ -82,8 +82,8 @@ this graph then allows you to easily compute gradients.
 This sounds complicated, it's pretty simple to use in practice. We wrap our
 PyTorch Tensors in **Variable** objects; a Variable represents a node in a
 computational graph. If `x` is a Variable then `x.data` is a Tensor, and
-`x.grad` is another Variable holding the gradient of `x` with respect to some
-scalar value.
+`x.grad` is another Variable holding the gradient of some scalar value with
+respect to `x`.
 
 PyTorch Variables have the same API as PyTorch Tensors: (almost) any operation
 that you can perform on a Tensor also works on Variables; the difference is that
@@ -101,9 +101,9 @@ network:
 ## PyTorch: Defining new autograd functions
 Under the hood, each primitive autograd operator is really two functions that
 operate on Tensors. The **forward** function computes output Tensors from input
-Tensors. The **backward** function receives the gradient of the output Tensors
-with respect to some scalar value, and computes the gradient of the input Tensors
-with respect to that same scalar value.
+Tensors. The **backward** function receives the gradient of some scalar value
+with respect to the output Tensors, and computes the gradient that same scalar
+value with respect to the input Tensors.
 
 In PyTorch we can easily define our own autograd operator by defining a subclass
 of `torch.autograd.Function` and implementing the `forward` and `backward` functions.

--- a/autograd/two_layer_net_autograd.py
+++ b/autograd/two_layer_net_autograd.py
@@ -10,8 +10,8 @@ Variables, and uses PyTorch autograd to compute gradients.
 
 A PyTorch Variable is a wrapper around a PyTorch Tensor, and represents a node
 in a computational graph. If x is a Variable then x.data is a Tensor giving its
-value, and x.grad is another Variable holding the gradient of x with respect to
-some scalar value.
+value, and x.grad is another Variable holding the gradient of some scalar value
+with respect to x.
 
 PyTorch Variables have the same API as PyTorch tensors: (almost) any operation
 you can do on a Tensor you can also do on a Variable; the difference is that

--- a/tensor/two_layer_net_numpy.py
+++ b/tensor/two_layer_net_numpy.py
@@ -35,7 +35,7 @@ for t in range(500):
   loss = np.square(y_pred - y).sum()
   print(t, loss)
   
-  # Backprop to compute gradients of w1 and w2 with respect to loss
+  # Backprop to compute gradients of loss with respect to w1 and w2
   grad_y_pred = 2.0 * (y_pred - y)
   grad_w2 = h_relu.T.dot(grad_y_pred)
   grad_h_relu = grad_y_pred.dot(w2.T)

--- a/tensor/two_layer_net_tensor.py
+++ b/tensor/two_layer_net_tensor.py
@@ -42,7 +42,7 @@ for t in range(500):
   loss = (y_pred - y).pow(2).sum()
   print(t, loss)
 
-  # Backprop to compute gradients of w1 and w2 with respect to loss
+  # Backprop to compute gradients of loss with respect to w1 and w2
   grad_y_pred = 2.0 * (y_pred - y)
   grad_w2 = h_relu.t().mm(grad_y_pred)
   grad_h_relu = grad_y_pred.mm(w2.t())


### PR DESCRIPTION
In several instances, documentation and comments incorrectly refer to the gradient of a tensor with respect to a scalar, when they should be the other way around.