### PR TITLE
getting an error without "backward" being @static

### DIFF
--- a/autograd/two_layer_net_custom_function.py
+++ b/autograd/two_layer_net_custom_function.py
@@ -26,7 +26,8 @@ class MyReLU(torch.autograd.Function):
     """
     ctx.save_for_backward(x)
     return x.clamp(min=0)
-
+ 
+  @staticmethod
   def backward(ctx, grad_output):
     """
     In the backward pass we receive the context object and a Tensor containing


### PR DESCRIPTION
```
(0, 34971804.0)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-51-7939c2c7bb7e> in <module>()
     59 
     60   # Use autograd to compute the backward pass.
---> 61   loss.backward()
     62 
     63   with torch.no_grad():

/Users/avloss/home/anaconda2/lib/python2.7/site-packages/torch/tensor.pyc in backward(self, gradient, retain_graph, create_graph)
     91                 products. Defaults to ``False``.
     92         """
---> 93         torch.autograd.backward(self, gradient, retain_graph, create_graph)
     94 
     95     def register_hook(self, hook):

/Users/avloss/home/anaconda2/lib/python2.7/site-packages/torch/autograd/__init__.pyc in backward(tensors, grad_tensors, retain_graph, create_graph, grad_variables)
     87     Variable._execution_engine.run_backward(
     88         tensors, grad_tensors, retain_graph, create_graph,
---> 89         allow_unreachable=True)  # allow_unreachable flag
     90 
     91 

/Users/avloss/home/anaconda2/lib/python2.7/site-packages/torch/autograd/function.pyc in apply(self, *args)
     74 
     75     def apply(self, *args):
---> 76         return self._forward_cls.backward(self, *args)
     77 
     78 

TypeError: unbound method backward() must be called with MyReLU instance as first argument (got MyReLUBackward instance instead)
```